### PR TITLE
Prevent async >=2 being used

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "description": "A XSLT package wrapping the XSLT interface of the Java API for XML Processing (JAXP)",
     "dependencies": {
         "java": ">=0.3.1",
-        "async": ">=0.4.0"
+        "async": ">=0.4.0 < 2.0.0"
     },
     "devDependencies": {
         "nodeunit": ">0.0.0"


### PR DESCRIPTION
The `async` dependency has just released 2.0.0 which isn't API compatible with 1.x versions. This PR limits the `async` version range to less than 2.
